### PR TITLE
fixed typo in readme for loading flymake-stan

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Include the following lines in your `.emacs` file,
 ;; Uncomment to activate yasnippet support (requires yasnippet)
 ;; (require 'stan-snippets)
 ;; Uncomment to activate flymake support (requires flymake)
-;; (require 'stan-flymake)
+;; (require 'flymake-stan)
 ```
 
 For Aquamacs on Mac OS X, those lines alternatively could also be


### PR DESCRIPTION
Perhaps the provide command of flymake-stan.el should be changed to (provide 'stan-flymake) for consistency with the other .el files stan provides?
