### PR TITLE
Fix compilation highlighting

### DIFF
--- a/stan-mode/stan-mode.el
+++ b/stan-mode/stan-mode.el
@@ -423,14 +423,17 @@ does not accept the `word' option."
 ;;; Compilation mode
 
 (defvar stan-compilation-regexp
-  '((stan-input-file . '("Input file=\\(.*\\)$" nil 1 nil nil))
-    (stan-error . '("ERROR at line \\([0-9]+\\)" 1 nil nil nil)))
+  '((stan-input-file . ("Input file=\\(.*\\)$" 1))
+    (stan-error . ("ERROR at line \\([0-9]+\\)" nil 1)))
   "Specifications for matching parse errors in Stan.
 
 See `compilation-error-regexp-alist' for a description of the format.")
 
-(add-to-list 'compilation-error-regexp-alist-alist stan-compilation-regexp)
-(add-to-list 'compilation-error-regexp-alist '(stan-input-file stan-error))
+(setq compilation-error-regexp-alist-alist
+      (append stan-compilation-regexp compilation-error-regexp-alist-alist))
+(setq compilation-error-regexp-alist
+      (append (mapcar #'car stan-compilation-regexp)
+              compilation-error-regexp-alist))
 
 ;;; Imenu mode
 


### PR DESCRIPTION
* Add each element of stan-compilation-regexp as an element to
  compilation-error-regexp-alist-alist rather than adding
  stan-compilation-regexp as a single element.  Do the same when adding
  the keys of stan-compilation-regexp to compilation-error-regexp-alist.

  This fixes type errors that were being signaled during any call to
  compile after Stan mode was loaded.

* Don't quote the regexp element.

  This would have led to a type error, if above had not already.

* Fix the regexp element so that FILE and LINE are correctly indicated.