### PR TITLE
Don't run stan-mode-hook twice

### DIFF
--- a/stan-mode/stan-mode.el
+++ b/stan-mode/stan-mode.el
@@ -494,7 +494,7 @@ Key bindings:
   (imenu-add-menubar-index)
 
   ;; conclusion
-  (run-hooks 'c-mode-common-hook 'stan-mode-hook)
+  (run-hooks 'c-mode-common-hook)
   )
 
 ;;;###autoload


### PR DESCRIPTION
The code generated by define-derived-mode automatically runs the defined
mode's hook, so explicitly running stan-mode-hook results in the hook
being run two times.