### PR TITLE
Remove (require 'cl')

### DIFF
--- a/stan-mode/stan-mode.el
+++ b/stan-mode/stan-mode.el
@@ -50,8 +50,6 @@
 ;; Warning: the function `c-populate-syntax-table' might not be defined at runtime.
 (require 'cc-langs)
 
-(require 'cl)
-
 (require 'font-lock)
 (require 'compile)
 


### PR DESCRIPTION
packages shouldn't require cl at runtime, and it doesn't seem to be
used anywhere anyway