### PR TITLE
Fix package URLs in commentaries

### DIFF
--- a/ac-stan/ac-stan.el
+++ b/ac-stan/ac-stan.el
@@ -6,7 +6,7 @@
 ;; Author: Jeffrey Arnold <jeffrey.arnold@gmail.com>,
 ;;         Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/ac-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/ac-stan
 ;; Keywords: languages
 ;; Version: 10.0.0
 ;; Created: 2014-12-18

--- a/ac-stan/test-ac-stan.el
+++ b/ac-stan/test-ac-stan.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/ac-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/ac-stan
 ;; Keywords: languages
 ;; Version: 10.0.0
 ;; Created: 2019-07-26

--- a/company-stan/company-stan.el
+++ b/company-stan/company-stan.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/company-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/company-stan
 ;; Keywords: languages
 ;; Version: 10.0.0
 ;; Created: 2019-07-14

--- a/company-stan/test-company-stan.el
+++ b/company-stan/test-company-stan.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/company-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/company-stan
 ;; Keywords: languages
 ;; Version: 10.0.0
 ;; Created: 2019-07-26

--- a/eldoc-stan/eldoc-stan-create-json.el
+++ b/eldoc-stan/eldoc-stan-create-json.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/eldoc-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/eldoc-stan
 ;; Keywords: help, tools
 ;; Version: 10.0.0
 ;; Created: 2019-07-29

--- a/eldoc-stan/eldoc-stan.el
+++ b/eldoc-stan/eldoc-stan.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/eldoc-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/eldoc-stan
 ;; Keywords: help, tools
 ;; Version: 10.0.0
 ;; Created: 2019-07-14

--- a/eldoc-stan/test-eldoc-stan-create-json.el
+++ b/eldoc-stan/test-eldoc-stan-create-json.el
@@ -2,7 +2,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/eldoc-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/eldoc-stan
 ;; Keywords: help, tools
 ;; Version: 10.0.0
 ;; Created: 2019-07-29

--- a/eldoc-stan/test-eldoc-stan.el
+++ b/eldoc-stan/test-eldoc-stan.el
@@ -2,7 +2,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/eldoc-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/eldoc-stan
 ;; Keywords: help, tools
 ;; Version: 10.0.0
 ;; Created: 2019-07-14

--- a/flycheck-stan/test-flycheck-stan-error-msgs.el
+++ b/flycheck-stan/test-flycheck-stan-error-msgs.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/flycheck-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/flycheck-stan
 ;; Keywords: languages
 ;; Version: 10.0.0
 ;; Created: 2019-07-26

--- a/flycheck-stan/test-flycheck-stan.el
+++ b/flycheck-stan/test-flycheck-stan.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/flycheck-stan
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/flycheck-stan
 ;; Keywords: languages
 ;; Version: 10.0.0
 ;; Created: 2019-07-26

--- a/stan-mode/create_stan_keywords.py
+++ b/stan-mode/create_stan_keywords.py
@@ -12,7 +12,7 @@ _TEMPLATE = """;;; {el_file} --- Variables used by `stan-mode' -*- lexical-bindi
 ;;         Daniel Lee <bearlee@alum.mit.edu>,
 ;;         Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/stan-mode
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/stan-mode
 ;; Keywords: languages,c
 ;; Version: 10.0.0
 ;; Created: 2012-08-18

--- a/stan-mode/stan-keywords.el
+++ b/stan-mode/stan-keywords.el
@@ -7,7 +7,7 @@
 ;;         Daniel Lee <bearlee@alum.mit.edu>,
 ;;         Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/stan-mode
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/stan-mode
 ;; Keywords: languages,c
 ;; Version: 10.0.0
 ;; Created: 2012-08-18

--- a/stan-mode/stan-mode.el
+++ b/stan-mode/stan-mode.el
@@ -7,7 +7,7 @@
 ;;         Daniel Lee <bearlee@alum.mit.edu>,
 ;;         Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/stan-mode
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/stan-mode
 ;; Keywords: languages,c
 ;; Version: 10.0.0
 ;; Created: 2012-08-18

--- a/stan-mode/test-stan-mode.el
+++ b/stan-mode/test-stan-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/stan-mode
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/stan-mode
 ;; Keywords: languages
 ;; Version: 10.0.0
 ;; Created: 2019-07-26

--- a/stan-snippets/stan-snippets.el
+++ b/stan-snippets/stan-snippets.el
@@ -6,7 +6,7 @@
 ;; Author: Jeffrey Arnold <jeffrey.arnold@gmail.com>,
 ;;         Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>
-;; URL: http://github.com/stan-dev/stan-mode/stan-snippets
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/stan-snippets
 ;; Keywords: languages,tools
 ;; Version: 10.0.0
 ;; Created: 2012-08-18

--- a/stan-snippets/test-stan-snippets.el
+++ b/stan-snippets/test-stan-snippets.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>,
 ;; Maintainer: Kazuki Yoshida <kazukiyoshida@mail.harvard.edu>,
-;; URL: http://github.com/stan-dev/stan-mode/stan-snippets
+;; URL: http://github.com/stan-dev/stan-mode/tree/master/stan-snippets
 ;; Keywords: languages,tools
 ;; Version: 10.0.0
 ;; Created: 2019-07-26


### PR DESCRIPTION
Add `tree/master/` to the package URL in each package's commentary.

For example, the following URL returns a 404 "Not Found" response:

    http://github.com/stan-dev/stan-mode/stan-mode

However, the following URL works:

    http://github.com/stan-dev/stan-mode/tree/master/stan-mode

* `ac-stan/ac-stan.el`:
* `ac-stan/test-ac-stan.el`:
* `company-stan/company-stan.el`:
* `company-stan/test-company-stan.el`:
* `eldoc-stan/eldoc-stan-create-json.el`:
* `eldoc-stan/eldoc-stan.el`:
* `eldoc-stan/test-eldoc-stan-create-json.el`:
* `eldoc-stan/test-eldoc-stan.el`:
* `flycheck-stan/test-flycheck-stan-error-msgs.el`:
* `flycheck-stan/test-flycheck-stan.el`:
* `stan-mode/create_stan_keywords.py` (`_TEMPLATE`):
* `stan-mode/stan-keywords.el`:
* `stan-mode/stan-mode.el`:
* `stan-mode/test-stan-mode.el`:
* `stan-snippets/stan-snippets.el`:
* `stan-snippets/test-stan-snippets.el`: Fix package URL in commentary.